### PR TITLE
fix(profile): correct env var reference in profile mod

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -41,5 +41,5 @@ p6df::modules::pagerduty::clones() {
 ######################################################################
 p6df::modules::pagerduty::profile::mod() {
 
-  p6_return_words 'pagerduty' "$"
+  p6_return_words 'pagerduty' '$PD_API_KEY'
 }


### PR DESCRIPTION
## What
Fix the `p6df::modules::pagerduty::profile::mod()` function to use `'$PD_API_KEY'` instead of a bare `"$"` as the env var argument to `p6_return_words`.

## Why
The previous value `"$"` was a broken/placeholder string that would not correctly reference the PagerDuty API key environment variable. This fix ensures the profile mod returns the correct env var name.

## Test plan
- Verified diff looks correct
- Function now references `\$PD_API_KEY` as intended

## Dependencies
None