### PR TITLE
fix(profile): simplify profile::mod return signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,7 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::pagerduty::clones()`
 - `p6df::modules::pagerduty::deps()`
-- `p6df::modules::pagerduty::profile::off()`
-- `p6df::modules::pagerduty::profile::on(profile, token)`
-  - Args:
-    - profile -
-    - token -
-- `str str = p6df::modules::pagerduty::prompt::mod()`
+- `words pagerduty = p6df::modules::pagerduty::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -31,10 +31,10 @@ p6df::modules::pagerduty::clones() {
 ######################################################################
 #<
 #
-# Function: words pagerduty $PD_API_KEY = p6df::modules::pagerduty::profile::mod()
+# Function: words pagerduty = p6df::modules::pagerduty::profile::mod()
 #
 #  Returns:
-#	words - pagerduty $PD_API_KEY
+#	words - pagerduty
 #
 #  Environment:	 PD_API_KEY
 #>


### PR DESCRIPTION
**What:** Remove env var from `profile::mod` return signature, returning only the module name word.

**Why:** Aligns with the updated `p6_return_words` convention where env vars are documented via the Environment section rather than encoded in the return value.

**Test plan:** Manual shell reload verification; no functional behavior change.

**Dependencies:** none